### PR TITLE
fix: improve error message logging

### DIFF
--- a/mitm/outboundinverter.go
+++ b/mitm/outboundinverter.go
@@ -227,7 +227,7 @@ func handleInverterMetrics0Packet(
 	var metrics OutboundInverterMetrics0Packet
 	err := metrics.UnmarshalBinary(data)
 	if err != nil {
-		return fmt.Errorf("couldn't unmarshal metrics: %v", err)
+		return fmt.Errorf("couldn't unmarshal metrics 0: %v", err)
 	}
 	di, ok := deviceInfo[metrics.DeviceID]
 	if !ok {
@@ -330,7 +330,7 @@ func handleInverterMetrics1Packet(
 	var metrics OutboundInverterMetrics1Packet
 	err := metrics.UnmarshalBinary(data)
 	if err != nil {
-		return fmt.Errorf("couldn't unmarshal metrics: %v", err)
+		return fmt.Errorf("couldn't unmarshal metrics 1: %v", err)
 	}
 	di, ok := deviceInfo[metrics.DeviceID]
 	if !ok {
@@ -379,7 +379,7 @@ func handleInverterTimeSyncPacket(
 	var timeSync OutboundInverterTimeSyncPacket
 	err := timeSync.UnmarshalBinary(data)
 	if err != nil {
-		return fmt.Errorf("couldn't unmarshal metrics: %v", err)
+		return fmt.Errorf("couldn't unmarshal time sync: %v", err)
 	}
 	di, ok := deviceInfo[timeSync.DeviceID]
 	if !ok {


### PR DESCRIPTION
* fix incorrect error log for timesync/metrics packet
* clarify which inverter metrics is referred to in unmarshal error
